### PR TITLE
Add profile page and coin titles shop

### DIFF
--- a/FantasyTrader/src/App.tsx
+++ b/FantasyTrader/src/App.tsx
@@ -10,6 +10,7 @@ import LobbyPage from './pages/LobbyPage';
 import DraftPage from './pages/DraftPage';
 import GamePage from './pages/GamePage';
 import HistoryPage from './pages/HistoryPage';
+import ProfilePage from './pages/ProfilePage';
 
 export default function App() {
   const initialize = useAuthStore(s => s.initialize);
@@ -30,6 +31,7 @@ export default function App() {
         <Route path="/draft/:roomId" element={<ProtectedRoute><DraftPage /></ProtectedRoute>} />
         <Route path="/game/:roomId" element={<ProtectedRoute><GamePage /></ProtectedRoute>} />
         <Route path="/history" element={<ProtectedRoute><HistoryPage /></ProtectedRoute>} />
+        <Route path="/profile" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />
       </Routes>
     </BrowserRouter>
   );

--- a/FantasyTrader/src/components/layout/Navbar.tsx
+++ b/FantasyTrader/src/components/layout/Navbar.tsx
@@ -1,13 +1,18 @@
 // Fixed top navigation bar — auth-aware
 
 import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { useState } from 'react';
 import { useAuthStore } from '../../store/authStore';
+import { TitleBadge } from '../ui/TitleBadge';
 
 /** Fixed top navbar with logo, page links, and auth state. */
 export function Navbar() {
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const { user, signOutUser } = useAuthStore();
+  const [photoFailed, setPhotoFailed] = useState(false);
+
+  const initial = user?.displayName?.charAt(0).toUpperCase() ?? '?';
 
   function navLinkClass(path: string) {
     return `text-sm transition-colors px-3 py-1.5 rounded-lg ${
@@ -38,11 +43,31 @@ export function Navbar() {
             <Link to="/sandbox" className={navLinkClass('/sandbox')}>Sandbox</Link>
             <Link to="/lobby" className={navLinkClass('/lobby')}>Lobby</Link>
             <Link to="/history" className={navLinkClass('/history')}>History</Link>
-            <div className="flex items-center gap-2 ml-2 pl-2 border-l border-zinc-700">
-              {user.photoURL && (
-                <img src={user.photoURL} alt={user.displayName} className="h-7 w-7 rounded-full" />
-              )}
-              <span className="text-zinc-300 text-sm hidden sm:block">{user.displayName}</span>
+            {/* Coin balance */}
+            <div className="flex items-center gap-1.5 bg-amber-500/10 border border-amber-500/20 rounded-full px-3 py-1">
+              <span className="text-sm select-none">🪙</span>
+              <span className="text-amber-400 text-sm font-semibold font-mono tabular-nums">{user.coins}</span>
+            </div>
+
+            <div className="flex items-center gap-2 ml-1 pl-2 border-l border-zinc-700">
+              <Link to="/profile" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
+                {user.photoURL && !photoFailed ? (
+                  <img
+                    src={user.photoURL}
+                    alt={user.displayName}
+                    className="h-7 w-7 rounded-full object-cover"
+                    onError={() => setPhotoFailed(true)}
+                  />
+                ) : (
+                  <div className="h-7 w-7 rounded-full bg-emerald-600 flex items-center justify-center text-white text-xs font-bold shrink-0">
+                    {initial}
+                  </div>
+                )}
+                <div className="hidden sm:flex flex-col items-start leading-none gap-1">
+                  <span className="text-zinc-300 text-sm">{user.displayName}</span>
+                  {user.title && <TitleBadge titleId={user.title} size="sm" />}
+                </div>
+              </Link>
               <button
                 onClick={handleSignOut}
                 className="text-zinc-400 hover:text-zinc-100 text-sm px-3 py-1.5 rounded-lg hover:bg-zinc-800 transition-colors cursor-pointer"

--- a/FantasyTrader/src/components/ui/TitleBadge.tsx
+++ b/FantasyTrader/src/components/ui/TitleBadge.tsx
@@ -1,0 +1,70 @@
+// Shared title badge — icon + label, used in Navbar and ProfilePage
+
+import type { ReactElement } from 'react';
+import { TITLE_MAP } from '../../lib/titles';
+
+// Each icon uses currentColor so the parent's text color class drives it
+const ICONS: Record<string, ReactElement> = {
+  day_trader: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      {/* Lightning bolt */}
+      <path d="M13 2L3.5 13.5H10.5L9 22L20.5 10.5H13.5L13 2Z" />
+    </svg>
+  ),
+  diamond_hands: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinejoin="round" className="w-full h-full">
+      {/* Diamond */}
+      <polygon points="12,2 22,10 12,22 2,10" />
+      <line x1="2" y1="10" x2="22" y2="10" />
+    </svg>
+  ),
+  bull_run: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-full h-full">
+      {/* Trending up — mirrors the app logo */}
+      <polyline points="22 7 13.5 15.5 8.5 10.5 2 17" />
+      <polyline points="16 7 22 7 22 13" />
+    </svg>
+  ),
+  bear_slayer: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      {/* Shield */}
+      <path d="M12 1L3 5V11C3 16.5 7 21.7 12 23C17 21.7 21 16.5 21 11V5L12 1Z" />
+    </svg>
+  ),
+  whale: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      {/* Bar chart */}
+      <rect x="3"  y="13" width="4" height="8" rx="1" />
+      <rect x="9"  y="8"  width="4" height="13" rx="1" />
+      <rect x="15" y="3"  width="4" height="18" rx="1" />
+    </svg>
+  ),
+  market_wizard: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+      {/* 4-pointed sparkle */}
+      <path d="M12 2C12 2 13 7.5 17 8.5C13 9.5 12 15 12 15C12 15 11 9.5 7 8.5C11 7.5 12 2 12 2Z" />
+      <path d="M19 14C19 14 19.5 17 21 17.5C19.5 18 19 21 19 21C19 21 18.5 18 17 17.5C18.5 17 19 14 19 14Z" />
+      <path d="M5 14C5 14 5.5 17 7 17.5C5.5 18 5 21 5 21C5 21 4.5 18 3 17.5C4.5 17 5 14 5 14Z" />
+    </svg>
+  ),
+};
+
+interface Props {
+  titleId: string;
+  /** 'sm' = navbar/inline use, 'md' = profile header */
+  size?: 'sm' | 'md';
+}
+
+/** Renders a styled title badge with a unique SVG icon. */
+export function TitleBadge({ titleId, size = 'sm' }: Props) {
+  const def = TITLE_MAP[titleId];
+  if (!def) return null;
+  const iconSize = size === 'md' ? 'w-4 h-4' : 'w-3 h-3';
+  const textSize = size === 'md' ? 'text-xs' : 'text-[10px]';
+  return (
+    <span className={`inline-flex items-center gap-1.5 border rounded-full font-medium ${def.color} ${def.bg} ${textSize} ${size === 'md' ? 'px-2.5 py-1' : 'px-2 py-0.5'}`}>
+      <span className={iconSize}>{ICONS[titleId]}</span>
+      {def.label}
+    </span>
+  );
+}

--- a/FantasyTrader/src/lib/titles.ts
+++ b/FantasyTrader/src/lib/titles.ts
@@ -1,0 +1,58 @@
+// Purchasable profile titles — shown next to display names across the app
+
+export interface TitleDef {
+  id: string;
+  label: string;
+  cost: number;
+  color: string;   // Tailwind text color class applied to the icon + badge text
+  bg: string;      // Tailwind bg + border classes for the badge pill
+}
+
+export const TITLES: TitleDef[] = [
+  {
+    id: 'day_trader',
+    label: 'Day Trader',
+    cost: 30,
+    color: 'text-sky-400',
+    bg: 'bg-sky-500/10 border-sky-500/25',
+  },
+  {
+    id: 'diamond_hands',
+    label: 'Diamond Hands',
+    cost: 50,
+    color: 'text-cyan-400',
+    bg: 'bg-cyan-500/10 border-cyan-500/25',
+  },
+  {
+    id: 'bull_run',
+    label: 'Bull Run',
+    cost: 75,
+    color: 'text-emerald-400',
+    bg: 'bg-emerald-500/10 border-emerald-500/25',
+  },
+  {
+    id: 'bear_slayer',
+    label: 'Bear Slayer',
+    cost: 75,
+    color: 'text-orange-400',
+    bg: 'bg-orange-500/10 border-orange-500/25',
+  },
+  {
+    id: 'whale',
+    label: 'Whale',
+    cost: 100,
+    color: 'text-blue-400',
+    bg: 'bg-blue-500/10 border-blue-500/25',
+  },
+  {
+    id: 'market_wizard',
+    label: 'Market Wizard',
+    cost: 150,
+    color: 'text-violet-400',
+    bg: 'bg-violet-500/10 border-violet-500/25',
+  },
+];
+
+export const TITLE_MAP: Record<string, TitleDef> = Object.fromEntries(
+  TITLES.map(t => [t.id, t]),
+);

--- a/FantasyTrader/src/pages/GamePage.tsx
+++ b/FantasyTrader/src/pages/GamePage.tsx
@@ -87,7 +87,7 @@ export default function GamePage() {
 
   const winner = room.winnerId;
   const isWinner = winner === user?.uid;
-  const isTie = !winner || (room.hostId === winner && room.guestId === winner);
+  const isTie = winner === null;
 
   function PickRow({ pick }: { pick: DraftPick }) {
     const current = prices[pick.symbol]?.price ?? pick.draftPrice;

--- a/FantasyTrader/src/pages/ProfilePage.tsx
+++ b/FantasyTrader/src/pages/ProfilePage.tsx
@@ -1,0 +1,263 @@
+// Profile page — player identity, stats, title shop, and coin transaction history
+
+import React, { useEffect, useState } from 'react';
+import { collection, query, where, orderBy, limit, getDocs } from 'firebase/firestore';
+import { db } from '../lib/firebase';
+import { useAuthStore } from '../store/authStore';
+import { LoadingSpinner } from '../components/ui/LoadingSpinner';
+import { TitleBadge } from '../components/ui/TitleBadge';
+import { TITLES, TITLE_MAP } from '../lib/titles';
+import type { CoinTransaction } from '../types';
+
+// SVG icons for the large title shop cards — same paths as TitleBadge but rendered bigger
+const SHOP_ICONS: Record<string, React.ReactElement> = {
+  day_trader: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-8 h-8">
+      <path d="M13 2L3.5 13.5H10.5L9 22L20.5 10.5H13.5L13 2Z" />
+    </svg>
+  ),
+  diamond_hands: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinejoin="round" className="w-8 h-8">
+      <polygon points="12,2 22,10 12,22 2,10" />
+      <line x1="2" y1="10" x2="22" y2="10" />
+    </svg>
+  ),
+  bull_run: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-8 h-8">
+      <polyline points="22 7 13.5 15.5 8.5 10.5 2 17" />
+      <polyline points="16 7 22 7 22 13" />
+    </svg>
+  ),
+  bear_slayer: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-8 h-8">
+      <path d="M12 1L3 5V11C3 16.5 7 21.7 12 23C17 21.7 21 16.5 21 11V5L12 1Z" />
+    </svg>
+  ),
+  whale: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-8 h-8">
+      <rect x="3"  y="13" width="4" height="8" rx="1" />
+      <rect x="9"  y="8"  width="4" height="13" rx="1" />
+      <rect x="15" y="3"  width="4" height="18" rx="1" />
+    </svg>
+  ),
+  market_wizard: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-8 h-8">
+      <path d="M12 2C12 2 13 7.5 17 8.5C13 9.5 12 15 12 15C12 15 11 9.5 7 8.5C11 7.5 12 2 12 2Z" />
+      <path d="M19 14C19 14 19.5 17 21 17.5C19.5 18 19 21 19 21C19 21 18.5 18 17 17.5C18.5 17 19 14 19 14Z" />
+      <path d="M5 14C5 14 5.5 17 7 17.5C5.5 18 5 21 5 21C5 21 4.5 18 3 17.5C4.5 17 5 14 5 14Z" />
+    </svg>
+  ),
+};
+
+function StatCard({ label, value, accent }: { label: string; value: string; accent?: 'emerald' | 'blue' }) {
+  const colors = { emerald: 'text-emerald-400', blue: 'text-blue-400' };
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-5 text-center">
+      <p className={`text-3xl font-bold font-mono ${accent ? colors[accent] : 'text-zinc-100'}`}>{value}</p>
+      <p className="text-zinc-500 text-xs mt-1.5 uppercase tracking-wide">{label}</p>
+    </div>
+  );
+}
+
+/** Profile page — player identity, lifetime stats, title shop, and coin history. */
+export default function ProfilePage() {
+  const user = useAuthStore(s => s.user);
+  const { purchaseTitle, equipTitle } = useAuthStore();
+  const [transactions, setTransactions] = useState<CoinTransaction[]>([]);
+  const [txLoading, setTxLoading] = useState(true);
+  const [titleLoading, setTitleLoading] = useState<string | null>(null);
+  const [titleError, setTitleError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user || !db) { setTxLoading(false); return; }
+    (async () => {
+      try {
+        const q = query(
+          collection(db!, 'coinTransactions'),
+          where('userId', '==', user.uid),
+          orderBy('timestamp', 'desc'),
+          limit(20),
+        );
+        const snap = await getDocs(q);
+        setTransactions(snap.docs.map(d => d.data() as CoinTransaction));
+      } catch {
+        setTransactions([]);
+      } finally {
+        setTxLoading(false);
+      }
+    })();
+  }, [user?.uid]);
+
+  if (!user) return <LoadingSpinner fullScreen />;
+
+  const winRate = user.gamesPlayed > 0
+    ? `${((user.gamesWon / user.gamesPlayed) * 100).toFixed(1)}%`
+    : '—';
+
+  const photoSrc = user.photoURL ?? null;
+  const owned = new Set(user.purchasedTitles ?? []);
+
+  async function handleTitleAction(titleId: string, cost: number, label: string) {
+    setTitleError(null);
+    setTitleLoading(titleId);
+    try {
+      if (owned.has(titleId)) {
+        await equipTitle(titleId);
+      } else {
+        await purchaseTitle(titleId, cost, label);
+      }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Purchase failed — check your connection and try again.';
+      setTitleError(msg);
+    } finally {
+      setTitleLoading(null);
+    }
+  }
+
+  return (
+    <div className="pt-14 min-h-screen bg-zinc-950">
+      <div className="max-w-4xl mx-auto px-4 py-10 space-y-10">
+
+        {/* Identity header */}
+        <div className="flex items-center gap-6">
+          {photoSrc ? (
+            <img src={photoSrc} alt={user.displayName} className="h-20 w-20 rounded-full ring-2 ring-zinc-700 object-cover" />
+          ) : (
+            <div className="h-20 w-20 rounded-full bg-emerald-600 flex items-center justify-center text-white text-3xl font-bold ring-2 ring-zinc-700">
+              {user.displayName.charAt(0).toUpperCase()}
+            </div>
+          )}
+          <div>
+            <h1 className="text-zinc-100 text-3xl font-bold tracking-tight">{user.displayName}</h1>
+            {user.title && (
+              <div className="mt-2">
+                <TitleBadge titleId={user.title} size="md" />
+              </div>
+            )}
+            <p className="text-zinc-500 text-sm mt-1.5">{user.email}</p>
+          </div>
+          {/* Coin balance */}
+          <div className="ml-auto inline-flex items-center gap-3 bg-amber-500/10 border border-amber-500/25 rounded-2xl px-6 py-3">
+            <span className="text-3xl select-none">🪙</span>
+            <div>
+              <p className="text-amber-300 text-3xl font-bold font-mono leading-none">{user.coins}</p>
+              <p className="text-amber-500/60 text-xs mt-0.5 uppercase tracking-wide">coins</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Stats */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <StatCard label="Games Played" value={String(user.gamesPlayed)} />
+          <StatCard label="Games Won" value={String(user.gamesWon)} accent="emerald" />
+          <StatCard label="Games Lost" value={String(user.gamesLost ?? 0)} />
+          <StatCard label="Win Rate" value={winRate} accent="blue" />
+        </div>
+
+        {/* Title shop */}
+        <div className="bg-zinc-900 border border-zinc-800 rounded-2xl overflow-hidden">
+          <div className="px-6 py-4 border-b border-zinc-800">
+            <h2 className="text-zinc-100 font-semibold">Titles</h2>
+            <p className="text-zinc-500 text-xs mt-0.5">Shown next to your name everywhere in the app</p>
+          </div>
+
+          {titleError && (
+            <div className="mx-4 mt-4 bg-red-500/10 border border-red-500/25 text-red-400 text-sm px-4 py-2.5 rounded-xl">
+              {titleError}
+            </div>
+          )}
+
+          <div className="p-4 grid grid-cols-2 sm:grid-cols-3 gap-3">
+            {TITLES.map(t => {
+              const def = TITLE_MAP[t.id];
+              const isOwned = owned.has(t.id);
+              const isEquipped = user.title === t.id;
+              const canAfford = user.coins >= t.cost;
+              const isLoading = titleLoading === t.id;
+
+              return (
+                <div
+                  key={t.id}
+                  className={`rounded-xl border p-4 flex flex-col gap-4 transition-colors
+                    ${isEquipped
+                      ? `${def.bg} border-opacity-60`
+                      : 'bg-zinc-800/50 border-zinc-700/60'
+                    }`}
+                >
+                  {/* Icon */}
+                  <div className={`${def.color}`}>
+                    {SHOP_ICONS[t.id]}
+                  </div>
+
+                  {/* Label + equipped badge */}
+                  <div className="flex items-center gap-2">
+                    <p className="text-zinc-100 font-semibold text-sm">{t.label}</p>
+                    {isEquipped && (
+                      <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full border ${def.bg} ${def.color}`}>On</span>
+                    )}
+                  </div>
+
+                  {/* Cost + action */}
+                  <div className="mt-auto flex items-center justify-between">
+                    <span className="text-zinc-500 text-xs font-mono">
+                      {isOwned ? 'Owned' : `${t.cost} 🪙`}
+                    </span>
+                    <button
+                      onClick={() => handleTitleAction(t.id, t.cost, t.label)}
+                      disabled={isEquipped || isLoading || (!isOwned && !canAfford)}
+                      className={`text-xs font-semibold px-3 py-1.5 rounded-lg transition-colors
+                        ${isEquipped
+                          ? 'text-zinc-600 cursor-default'
+                          : isLoading
+                            ? 'bg-zinc-700 text-zinc-400 cursor-wait'
+                            : isOwned
+                              ? 'bg-zinc-700 hover:bg-zinc-600 text-zinc-200 cursor-pointer'
+                              : canAfford
+                                ? 'bg-amber-500 hover:bg-amber-400 text-black cursor-pointer'
+                                : 'bg-zinc-700/50 text-zinc-600 cursor-not-allowed'
+                        }`}
+                    >
+                      {isLoading ? '…' : isEquipped ? 'Equipped' : isOwned ? 'Equip' : 'Buy'}
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Coin history */}
+        <div className="bg-zinc-900 border border-zinc-800 rounded-2xl overflow-hidden">
+          <div className="px-6 py-4 border-b border-zinc-800">
+            <h2 className="text-zinc-100 font-semibold">Coin History</h2>
+          </div>
+          {txLoading ? (
+            <div className="py-14 text-center text-zinc-500 text-sm">Loading…</div>
+          ) : transactions.length === 0 ? (
+            <div className="py-16 text-center space-y-2">
+              <p className="text-zinc-500 text-sm">No transactions yet.</p>
+              <p className="text-zinc-600 text-xs">Win a draft game to earn coins.</p>
+            </div>
+          ) : (
+            <div className="divide-y divide-zinc-800/60">
+              {transactions.map(tx => (
+                <div key={tx.id} className="flex items-center justify-between px-6 py-3.5">
+                  <div>
+                    <p className="text-zinc-200 text-sm">{tx.reason}</p>
+                    <p className="text-zinc-600 text-xs mt-0.5">
+                      {new Date(tx.timestamp).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short' })}
+                    </p>
+                  </div>
+                  <span className={`font-mono font-bold text-sm tabular-nums ${tx.amount > 0 ? 'text-amber-400' : 'text-red-400'}`}>
+                    {tx.amount > 0 ? `+${tx.amount}` : tx.amount}&nbsp;🪙
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/FantasyTrader/src/store/authStore.ts
+++ b/FantasyTrader/src/store/authStore.ts
@@ -7,7 +7,7 @@ import {
   signOut,
   type User as FirebaseUser,
 } from 'firebase/auth';
-import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { doc, getDoc, setDoc, updateDoc, arrayUnion, increment, collection, writeBatch } from 'firebase/firestore';
 import { auth, googleProvider, db } from '../lib/firebase';
 import type { User } from '../types';
 
@@ -24,6 +24,10 @@ interface AuthState {
   signOutUser: () => Promise<void>;
   /** Re-fetch the user document from Firestore. */
   refreshUser: () => Promise<void>;
+  /** Buy a title for the first time — deducts coins, adds to purchasedTitles, and equips it. */
+  purchaseTitle: (titleId: string, cost: number, label: string) => Promise<void>;
+  /** Switch to an already-owned title (free). */
+  equipTitle: (titleId: string) => Promise<void>;
 }
 
 export const useAuthStore = create<AuthState>((set, get) => ({
@@ -46,7 +50,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         email: fbUser.email ?? '',
         displayName: fbUser.displayName ?? 'Player',
         photoURL: fbUser.photoURL ?? undefined,
-        coins: 100,
+        coins: 0,
         gamesPlayed: 0,
         gamesWon: 0,
         gamesLost: 0,
@@ -93,5 +97,36 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     if (!firebaseUser || !db) return;
     const snap = await getDoc(doc(db, 'users', firebaseUser.uid));
     if (snap.exists()) set({ user: { gamesLost: 0, gamesTied: 0, ...snap.data() } as User });
+  },
+
+  async purchaseTitle(titleId, cost, label) {
+    const { firebaseUser } = get();
+    if (!firebaseUser || !db) return;
+    const batch = writeBatch(db);
+    const userRef = doc(db, 'users', firebaseUser.uid);
+    // Deduct coins, add to owned list, equip immediately
+    batch.update(userRef, {
+      coins: increment(-cost),
+      purchasedTitles: arrayUnion(titleId),
+      title: titleId,
+    });
+    // Coin transaction for profile history
+    const txRef = doc(collection(db, 'coinTransactions'));
+    batch.set(txRef, {
+      id: txRef.id,
+      userId: firebaseUser.uid,
+      amount: -cost,
+      reason: `Purchased title: ${label}`,
+      timestamp: Date.now(),
+    });
+    await batch.commit();
+    await get().refreshUser();
+  },
+
+  async equipTitle(titleId) {
+    const { firebaseUser } = get();
+    if (!firebaseUser || !db) return;
+    await updateDoc(doc(db, 'users', firebaseUser.uid), { title: titleId });
+    await get().refreshUser();
   },
 }));

--- a/FantasyTrader/src/store/gameStore.ts
+++ b/FantasyTrader/src/store/gameStore.ts
@@ -120,11 +120,24 @@ export const useGameStore = create<GameState>((set) => ({
 
   async recordMyResult(userId, winnerId, coinReward) {
     if (!db) return;
-    const outcome = winnerId === userId
+    const isWinner = winnerId === userId;
+    const isTie = winnerId === null;
+    const outcome = isWinner
       ? { gamesWon: increment(1), coins: increment(coinReward) }
-      : winnerId === null
+      : isTie
         ? { gamesTied: increment(1) }
         : { gamesLost: increment(1) };
     await updateDoc(doc(db, 'users', userId), { gamesPlayed: increment(1), ...outcome });
+    // Write audit record so Profile page can show coin history
+    if (isWinner && coinReward > 0) {
+      const txRef = doc(collection(db, 'coinTransactions'));
+      await setDoc(txRef, {
+        id: txRef.id,
+        userId,
+        amount: coinReward,
+        reason: 'Won a draft game',
+        timestamp: Date.now(),
+      });
+    }
   },
 }));

--- a/FantasyTrader/src/types/index.ts
+++ b/FantasyTrader/src/types/index.ts
@@ -60,6 +60,8 @@ export interface User {
   gamesLost: number;
   gamesTied: number;
   createdAt: number;
+  title?: string;
+  purchasedTitles?: string[];
 }
 
 export interface DraftPick {
@@ -97,4 +99,12 @@ export interface GamePortfolio {
   currentValue: number;
   startValue: number;
   gainPercent: number;
+}
+
+export interface CoinTransaction {
+  id: string;
+  userId: string;
+  amount: number;
+  reason: string;
+  timestamp: number;
 }


### PR DESCRIPTION
## Summary
- Profile page with stats, coin balance, and transaction history
- Purchasable titles (Day Trader, Diamond Hands, Bull Run, Bear Slayer, Whale, Market Wizard) shown next to player name in navbar
- Coin transactions tracked on game wins and title purchases
- Starting coins set to 0, 50 coins per win