### PR TITLE
Add profile page, coin titles shop, and leaderboard title badges

### DIFF
--- a/FantasyTrader/src/components/ui/TitleBadge.tsx
+++ b/FantasyTrader/src/components/ui/TitleBadge.tsx
@@ -1,39 +1,33 @@
-// Shared title badge — icon + label, used in Navbar and ProfilePage
+// Shared title badge — icon + label, used in Navbar, Leaderboard, and ProfilePage
 
 import type { ReactElement } from 'react';
 import { TITLE_MAP } from '../../lib/titles';
 
-// Each icon uses currentColor so the parent's text color class drives it
 const ICONS: Record<string, ReactElement> = {
   day_trader: (
     <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
-      {/* Lightning bolt */}
       <path d="M13 2L3.5 13.5H10.5L9 22L20.5 10.5H13.5L13 2Z" />
     </svg>
   ),
   diamond_hands: (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinejoin="round" className="w-full h-full">
-      {/* Diamond */}
       <polygon points="12,2 22,10 12,22 2,10" />
       <line x1="2" y1="10" x2="22" y2="10" />
     </svg>
   ),
   bull_run: (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-full h-full">
-      {/* Trending up — mirrors the app logo */}
       <polyline points="22 7 13.5 15.5 8.5 10.5 2 17" />
       <polyline points="16 7 22 7 22 13" />
     </svg>
   ),
   bear_slayer: (
     <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
-      {/* Shield */}
       <path d="M12 1L3 5V11C3 16.5 7 21.7 12 23C17 21.7 21 16.5 21 11V5L12 1Z" />
     </svg>
   ),
   whale: (
     <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
-      {/* Bar chart */}
       <rect x="3"  y="13" width="4" height="8" rx="1" />
       <rect x="9"  y="8"  width="4" height="13" rx="1" />
       <rect x="15" y="3"  width="4" height="18" rx="1" />
@@ -41,7 +35,6 @@ const ICONS: Record<string, ReactElement> = {
   ),
   market_wizard: (
     <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
-      {/* 4-pointed sparkle */}
       <path d="M12 2C12 2 13 7.5 17 8.5C13 9.5 12 15 12 15C12 15 11 9.5 7 8.5C11 7.5 12 2 12 2Z" />
       <path d="M19 14C19 14 19.5 17 21 17.5C19.5 18 19 21 19 21C19 21 18.5 18 17 17.5C18.5 17 19 14 19 14Z" />
       <path d="M5 14C5 14 5.5 17 7 17.5C5.5 18 5 21 5 21C5 21 4.5 18 3 17.5C4.5 17 5 14 5 14Z" />
@@ -51,19 +44,27 @@ const ICONS: Record<string, ReactElement> = {
 
 interface Props {
   titleId: string;
-  /** 'sm' = navbar/inline use, 'md' = profile header */
+  /** 'sm' = inline use (navbar, leaderboard), 'md' = profile header */
   size?: 'sm' | 'md';
 }
 
-/** Renders a styled title badge with a unique SVG icon. */
+/** Renders a title badge with icon and label. */
 export function TitleBadge({ titleId, size = 'sm' }: Props) {
   const def = TITLE_MAP[titleId];
   if (!def) return null;
-  const iconSize = size === 'md' ? 'w-4 h-4' : 'w-3 h-3';
-  const textSize = size === 'md' ? 'text-xs' : 'text-[10px]';
+
+  if (size === 'sm') {
+    return (
+      <span className={`inline-flex items-center gap-1 rounded pl-1.5 pr-1 py-0.5 border w-fit ${def.color} ${def.bg}`}>
+        <span className="w-2.5 h-2.5 shrink-0">{ICONS[titleId]}</span>
+        <span className="text-[10px] font-medium tracking-wide whitespace-nowrap">{def.label}</span>
+      </span>
+    );
+  }
+
   return (
-    <span className={`inline-flex items-center gap-1.5 border rounded-full font-medium ${def.color} ${def.bg} ${textSize} ${size === 'md' ? 'px-2.5 py-1' : 'px-2 py-0.5'}`}>
-      <span className={iconSize}>{ICONS[titleId]}</span>
+    <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 border text-xs font-medium ${def.color} ${def.bg}`}>
+      <span className="w-3.5 h-3.5 shrink-0">{ICONS[titleId]}</span>
       {def.label}
     </span>
   );

--- a/FantasyTrader/src/pages/LeaderboardPage.tsx
+++ b/FantasyTrader/src/pages/LeaderboardPage.tsx
@@ -3,6 +3,7 @@ import { collection, query, orderBy, limit, getDocs } from 'firebase/firestore';
 import { db } from '../lib/firebase';
 import { useAuthStore } from '../store/authStore';
 import { LoadingSpinner } from '../components/ui/LoadingSpinner';
+import { TitleBadge } from '../components/ui/TitleBadge';
 import type { User } from '../types';
 
 export default function LeaderboardPage() {
@@ -66,7 +67,7 @@ export default function LeaderboardPage() {
                     {i + 1}
                   </span>
 
-                  {/* Avatar + name */}
+                  {/* Avatar + name + title */}
                   <div className="flex items-center gap-2.5 min-w-0">
                     {player.photoURL ? (
                       <img src={player.photoURL} alt={player.displayName} referrerPolicy="no-referrer" className="h-7 w-7 rounded-full flex-shrink-0" />
@@ -75,10 +76,13 @@ export default function LeaderboardPage() {
                         {initial}
                       </div>
                     )}
-                    <span className={`text-sm font-medium truncate ${isMe ? 'text-emerald-300' : 'text-zinc-200'}`}>
-                      {player.displayName}
-                      {isMe && <span className="ml-1.5 text-xs text-emerald-500 font-normal">you</span>}
-                    </span>
+                    <div className="flex flex-col min-w-0">
+                      <span className={`text-sm font-medium truncate ${isMe ? 'text-emerald-300' : 'text-zinc-200'}`}>
+                        {player.displayName}
+                        {isMe && <span className="ml-1.5 text-xs text-emerald-500 font-normal">you</span>}
+                      </span>
+                      {player.title && <TitleBadge titleId={player.title} size="sm" />}
+                    </div>
                   </div>
 
                   {/* Wins */}


### PR DESCRIPTION
## Summary
- Profile page with stats, coin balance, and transaction history
- Purchasable titles shop (Day Trader, Diamond Hands, Bull Run, Bear Slayer, Whale, Market Wizard)
- Title badges shown in navbar, profile header, and leaderboard rows
- Coin transactions tracked on game wins and title purchases
- Starting coins set to 0, 50 coins per win