### PR TITLE
Fix double game log increment on completion

### DIFF
--- a/FantasyTrader/src/pages/GamePage.tsx
+++ b/FantasyTrader/src/pages/GamePage.tsx
@@ -61,22 +61,25 @@ export default function GamePage() {
   }, [room, roomId, hostPicks, guestPicks, prices, completeGame, user]);
 
   useEffect(() => {
-    if (!room?.endTime) return;
+    // Stop ticking once the game is over — prevents checkEnd from re-showing the modal
+    if (!room?.endTime || room.status === 'completed') return;
     const tick = setInterval(() => {
       setCountdown(formatCountdown(room.endTime!));
       checkEnd();
     }, 1000);
     setCountdown(formatCountdown(room.endTime));
     return () => clearInterval(tick);
-  }, [room?.endTime, checkEnd]);
+  }, [room?.endTime, room?.status, checkEnd]);
 
-  // When room reaches completed state, each player records their own result once
+  // When room reaches completed state, each player records their own result once.
+  // Deps intentionally limited to room.status — user updates from refreshUser must not re-trigger this.
   useEffect(() => {
     if (room?.status !== 'completed' || !user || recordedRef.current) return;
     recordedRef.current = true;
     recordMyResult(user.uid, room.id, room.winnerId, room.coinReward).then(() => refreshUser());
     setShowWinner(true);
-  }, [room?.status, room?.winnerId, room?.coinReward, user, recordMyResult, refreshUser]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [room?.status]);
 
   // Redirect if room isn't active yet
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Stop the countdown interval once `room.status === 'completed'` so `checkEnd` can no longer reopen the winner modal every second
- Pin the recording `useEffect` to `room.status` only — previously `user` was in the dep array, causing the effect to refire after `refreshUser()` updated the user object, double-counting gamesPlayed